### PR TITLE
Deprecate in favor of freshdesk-api (v2)

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,18 @@
 # freshdesk-sdk-node
+
 Freshdesk API client for node.js
+
+**WARNING**
+
+[![npm version](https://img.shields.io/badge/NPM-deprecated-red.svg)](https://github.com/maxkoryukov/node-freshdesk-api/issues/1)
+
+This repository and corresponding NPM package are deprecated in favor of [**freshdesk-api**](https://www.npmjs.com/package/freshdesk-api).
+
+Useful links:
+
+1. [NPM package](https://www.npmjs.com/package/freshdesk-api):
+    * v2 is **preferred**: `npm install freshdesk-api`
+    * v1: `npm install freshdesk-api@APIv1`
+2. GitHub, `node-freshdesk-api`:
+    * [v2 on master branch](https://github.com/arjunkomath/node-freshdesk-api)
+    * [v1 in additional branch](https://github.com/arjunkomath/node-freshdesk-api/tree/API-v1)

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "freshdesk-sdk",
-  "version": "0.0.1",
+  "version": "1.0.0",
   "description": "Freshdesk API client for Node.js",
   "main": "index.js",
   "scripts": {


### PR DESCRIPTION
Hello, I would like to offer you to take part in this open source, github-based freshdesk-project: https://github.com/arjunkomath/node-freshdesk-api . I'm sure, this project could be a good alternative for your project.
 
So, if you are not going to maintain **your** project in the future:

1. Merge this PR to your repository
1. Publish your old package on NPM (to publish the new `README.md` on NPM)
    ```shell
    npm publish
    ```
1. Deprecate your old NPM package, with this command:
    ```shell
    npm deprecate freshdesk-sdk "Please, use this package: freshdesk-api"
    ```

**Don't unpublish** your package, it is enough to deprecate it :+1: 

### Checklist

* [ ] merge PR
* [ ] publish on NPM
* [ ] deprecate on NPM

PS: this PR is a part of maxkoryukov/node-freshdesk-api#1